### PR TITLE
feat(homebrew): Add Homebrew Tap formula and installation docs (Closes #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,34 @@ chatmate uninstall "Rarely Used"  # Clean up
 
 ## 🔧 Installation Methods
 
-### CLI Installation (Recommended)
+git clone https://github.com/jonassiebler/chatmate.git
+go build -o chatmate .
 
-Build and install the ChatMate CLI tool:
+### Homebrew Tap Installation (Recommended)
 
+Install ChatMate easily via Homebrew:
+
+```bash
+# Add the ChatMate tap
+brew tap jonassiebler/chatmate
+
+# Install the CLI
+brew install chatmate
+
+# (Optional) Update to latest version
+brew upgrade chatmate
+
+# Install all chatmates
+chatmate hire
+```
+
+**That's it!** Restart VS Code and start using your new chatmates with `@ChatmateName` in Copilot Chat.
+
+---
+
+### CLI Installation (Manual)
+
+Build and install the ChatMate CLI tool manually:
 
 ```bash
 # Clone the repository

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -11,39 +11,32 @@ Before installing ChatMate, ensure you have:
 - ✅ **Active GitHub Copilot subscription**
 - ✅ **Write permissions** to your VS Code user directory
 
+
 ## Quick Installation (Recommended)
 
-### 1. Get ChatMate CLI
-
-#### Option A: Download Release Binary
+### 1. Install via Homebrew Tap (Easiest)
 
 ```bash
-# Download the latest release for your platform
-# Extract and move to your PATH
+# Add the ChatMate tap
+brew tap jonassiebler/chatmate
+
+# Install the CLI
+brew install chatmate
+
+# (Optional) Update to latest version
+brew upgrade chatmate
+
+# Install all chatmates
+chatmate hire
 ```
 
-#### Option B: Build from Source
-
-```bash
-git clone https://github.com/jonassiebler/chatmate.git
-cd chatmate
-go build -o chatmate .
-```
-
-### 2. Install All Chatmates
-
-```bash
-# Install all available chatmates (recommended for new users)
-./chatmate hire
-```
-
-### 3. Restart VS Code
+### 2. Restart VS Code
 
 - Close all VS Code windows
 - Reopen VS Code
 - Open Copilot Chat (`Ctrl/Cmd+Shift+P` → "Chat: Open Chat")
 
-### 4. Test Installation
+### 3. Test Installation
 
 In VS Code Copilot Chat, try:
 ```
@@ -51,6 +44,29 @@ In VS Code Copilot Chat, try:
 ```
 
 If you see a response from the Solve Issue chatmate, you're all set! 🎉
+
+---
+
+### Manual Installation (Alternative)
+
+```bash
+# Download the latest release for your platform
+# Extract and move to your PATH
+```
+
+Or build from source:
+
+```bash
+git clone https://github.com/jonassiebler/chatmate.git
+cd chatmate
+go build -o chatmate .
+```
+
+Install all chatmates:
+
+```bash
+./chatmate hire
+```
 
 ## Alternative Installation Methods
 

--- a/homebrew-tap/Formula/chatmate.rb
+++ b/homebrew-tap/Formula/chatmate.rb
@@ -1,0 +1,21 @@
+class Chatmate < Formula
+  desc "AI-powered CLI for managing VS Code Copilot Chat agents (chatmates)"
+  homepage "https://github.com/jonassiebler/chatmate"
+  url "https://github.com/jonassiebler/chatmate.git",
+      using:    :git,
+      revision: "cd8718b"
+  version "20250817113552"
+  license "MIT"
+  head "https://github.com/jonassiebler/chatmate.git", branch: "dev"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(output: bin/"chatmate"), "."
+    man1.install "docs/man/chatmate.1"
+  end
+
+  test do
+    assert_match "ChatMate", shell_output("#{bin}/chatmate --help")
+  end
+end


### PR DESCRIPTION
This PR adds a Homebrew Tap formula for the Chatmate CLI and updates documentation to include Homebrew installation instructions. Closes #6.